### PR TITLE
Remove sqs queues urls

### DIFF
--- a/bin/fake_sns
+++ b/bin/fake_sns
@@ -12,6 +12,7 @@ options = {
   :verbose   => false,
   :daemonize => false,
   :database  => nil,
+  :remove_sqs_queues_url => false,
 }
 
 parser = OptionParser.new do |o|
@@ -30,6 +31,11 @@ parser = OptionParser.new do |o|
 
   o.on "-s", "--server SERVER", ['thin', 'mongrel', 'webrick'], "Server to use: thin, mongrel or webrick (by default Sinatra chooses the best available)" do |server|
     options[:server] = server
+  end
+
+  o.on "-r", "--remove_sqs_queues_url", "Removes Aws::Plugins::SQSQueueUrls" do |queues_url|
+    puts "-- Aws::SQS::Client.remove_plugin(Aws::Plugins::SQSQueueUrls)"
+    options[:remove_sqs_queues_url] = queues_url
   end
 
   o.on "-P", "--pid PIDFILE", "Where to write the pid" do |pid|
@@ -57,6 +63,10 @@ parser = OptionParser.new do |o|
 end
 
 parser.parse!
+
+if options[:remove_sqs_queues_url]
+  Aws::SQS::Client.remove_plugin(Aws::Plugins::SQSQueueUrls)
+end
 
 if options[:daemonize]
   Process.daemon(true, true)

--- a/fake_sns.gemspec
+++ b/fake_sns.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "virtus", "~> 1.0"
   spec.add_dependency "verbose_hash_fetch"
   spec.add_dependency "faraday", "~> 0.8"
-  spec.add_dependency 'aws-sdk', '~> 2.0'
+  spec.add_dependency 'aws-sdk', "~> 2.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Updates aws-sdk gem and adds option to remove Aws::Plugins::SQSQueueUrls to be able to test locally.
