### PR TITLE
Add create platform application/endpoint; publish to target endpoint.

### DIFF
--- a/lib/fake_sns.rb
+++ b/lib/fake_sns.rb
@@ -10,6 +10,8 @@ require "fake_sns/error_response"
 require "fake_sns/database"
 require "fake_sns/storage"
 
+require "fake_sns/platform_endpoint_collection"
+require "fake_sns/platform_endpoint"
 require "fake_sns/topic_collection"
 require "fake_sns/topic"
 require "fake_sns/subscription_collection"

--- a/lib/fake_sns.rb
+++ b/lib/fake_sns.rb
@@ -10,6 +10,8 @@ require "fake_sns/error_response"
 require "fake_sns/database"
 require "fake_sns/storage"
 
+require "fake_sns/platform_application_collection"
+require "fake_sns/platform_application"
 require "fake_sns/platform_endpoint_collection"
 require "fake_sns/platform_endpoint"
 require "fake_sns/topic_collection"

--- a/lib/fake_sns/actions/create_platform_application.rb
+++ b/lib/fake_sns/actions/create_platform_application.rb
@@ -1,0 +1,37 @@
+module FakeSNS
+  module Actions
+    class CreatePlatformApplication < Action
+
+      param name: "Name"
+      param platform: "Platform"
+
+      def call
+        @application = (existing_application || new_application)
+      end
+
+      def arn
+        application["arn"]
+      end
+
+      attr_reader :application
+
+      private
+
+      def new_application
+        arn = generate_arn
+        application_attributes = { "arn" => arn, "name" => name, "platform" => platform }
+        db.platform_applications.create(application_attributes)
+        application_attributes
+      end
+
+      def generate_arn
+        "arn:aws:sns:us-east-1:#{SecureRandom.hex}"
+      end
+
+      def existing_application
+        db.platform_applications.find { |t| t["name"] == name && t["platform"] == platform }
+      end
+
+    end
+  end
+end

--- a/lib/fake_sns/actions/create_platform_endpoint.rb
+++ b/lib/fake_sns/actions/create_platform_endpoint.rb
@@ -1,0 +1,37 @@
+module FakeSNS
+  module Actions
+    class CreatePlatformEndpoint < Action
+
+      param app_arn: "PlatformApplicationArn"
+      param token: "Token"
+
+      def call
+        @endpoint = (existing_endpoint || new_endpoint)
+      end
+
+      def arn
+        endpoint["arn"]
+      end
+
+      attr_reader :endpoint
+
+      private
+
+      def new_endpoint
+        arn = generate_arn
+        endpoint_attributes = { "arn" => arn, "app_arn" => app_arn, "token" => token }
+        db.topics.create(endpoint_attributes)
+        endpoint_attributes
+      end
+
+      def generate_arn
+        "arn:aws:sns:us-east-1:#{SecureRandom.hex}"
+      end
+
+      def existing_endpoint
+        db.platform_endpoints.find { |t| t["app_arn"] == app_arn && t["token"] == token }
+      end
+
+    end
+  end
+end

--- a/lib/fake_sns/actions/create_platform_endpoint.rb
+++ b/lib/fake_sns/actions/create_platform_endpoint.rb
@@ -19,8 +19,8 @@ module FakeSNS
 
       def new_endpoint
         arn = generate_arn
-        endpoint_attributes = { "arn" => arn, "app_arn" => app_arn, "token" => token }
-        db.topics.create(endpoint_attributes)
+        endpoint_attributes = { "arn" => arn, "platform_application_arn" => app_arn, "token" => token }
+        db.platform_endpoints.create(endpoint_attributes)
         endpoint_attributes
       end
 
@@ -29,7 +29,7 @@ module FakeSNS
       end
 
       def existing_endpoint
-        db.platform_endpoints.find { |t| t["app_arn"] == app_arn && t["token"] == token }
+        db.platform_endpoints.find { |t| t["platform_application_arn"] == app_arn && t["token"] == token }
       end
 
     end

--- a/lib/fake_sns/actions/publish.rb
+++ b/lib/fake_sns/actions/publish.rb
@@ -12,8 +12,14 @@ module FakeSNS
         if (bytes = message.bytesize) > 262144
           raise InvalidParameterValue, "Too much bytes: #{bytes} > 262144."
         end
-        @topic = db.topics.fetch(topic_arn) do
-          raise InvalidParameterValue, "Unknown topic: #{topic_arn}"
+        if topic_arn.nil?
+          @platform_endpoint = db.platform_endpoints.fetch(target_arn) do
+            raise InvalidParameterValue, "Unknown target: #{target_arn}"
+          end
+        else
+          @topic = db.topics.fetch(topic_arn) do
+            raise InvalidParameterValue, "Unknown topic: #{topic_arn}"
+          end
         end
         @message_id = SecureRandom.uuid
 

--- a/lib/fake_sns/database.rb
+++ b/lib/fake_sns/database.rb
@@ -28,6 +28,10 @@ module FakeSNS
       @messages ||= MessageCollection.new(store)
     end
 
+    def platform_applications
+      @platform_applications ||= PlatformApplicationCollection.new(store)
+    end
+
     def platform_endpoints
       @platform_endpoints ||= PlatformEndpointCollection.new(store)
     end
@@ -36,6 +40,7 @@ module FakeSNS
       topics.reset
       subscriptions.reset
       messages.reset
+      platform_applications.reset
       platform_endpoints.reset
     end
 

--- a/lib/fake_sns/database.rb
+++ b/lib/fake_sns/database.rb
@@ -28,10 +28,15 @@ module FakeSNS
       @messages ||= MessageCollection.new(store)
     end
 
+    def platform_endpoints
+      @platform_endpoints ||= PlatformEndpointCollection.new(store)
+    end
+
     def reset
       topics.reset
       subscriptions.reset
       messages.reset
+      platform_endpoints.reset
     end
 
     def transaction

--- a/lib/fake_sns/platform_application.rb
+++ b/lib/fake_sns/platform_application.rb
@@ -1,0 +1,11 @@
+module FakeSNS
+  class PlatformApplication
+
+    include Virtus.model
+
+    attribute :arn, String
+    attribute :name, String
+    attribute :platform, String
+
+  end
+end

--- a/lib/fake_sns/platform_application_collection.rb
+++ b/lib/fake_sns/platform_application_collection.rb
@@ -1,0 +1,42 @@
+module FakeSNS
+  class PlatformApplicationCollection
+
+    include Enumerable
+
+    attr_reader :collection
+
+    def initialize(store)
+      @store = store
+      @store["platform_applications"] ||= []
+    end
+
+    def collection
+      @store["platform_applications"]
+    end
+
+    def reset
+      @store["platform_applications"] = []
+    end
+
+    def each(*args, &block)
+      collection.map { |item| PlatformApplication.new(item) }.each(*args, &block)
+    end
+
+    def create(attributes)
+      collection << attributes
+    end
+
+    def delete(arn)
+      collection.delete(fetch(arn))
+    end
+
+    def fetch(arn, &default)
+      default ||= -> { raise InvalidParameterValue, "Unknown platform application #{arn}" }
+      found = collection.find do |platform_application|
+        platform_application["arn"] == arn
+      end
+      found || default.call
+    end
+
+  end
+end

--- a/lib/fake_sns/platform_endpoint.rb
+++ b/lib/fake_sns/platform_endpoint.rb
@@ -1,0 +1,11 @@
+module FakeSNS
+  class PlatformEndpoint
+
+    include Virtus.model
+
+    attribute :arn, String
+    attribute :platform_application_arn, String
+    attribute :token, String
+
+  end
+end

--- a/lib/fake_sns/platform_endpoint_collection.rb
+++ b/lib/fake_sns/platform_endpoint_collection.rb
@@ -1,0 +1,42 @@
+module FakeSNS
+  class PlatformEndpointCollection
+
+    include Enumerable
+
+    attr_reader :collection
+
+    def initialize(store)
+      @store = store
+      @store["platform_endpoints"] ||= []
+    end
+
+    def collection
+      @store["platform_endpoints"]
+    end
+
+    def reset
+      @store["platform_endpoints"] = []
+    end
+
+    def each(*args, &block)
+      collection.map { |item| PlatformEndpoint.new(item) }.each(*args, &block)
+    end
+
+    def create(attributes)
+      collection << attributes
+    end
+
+    def delete(arn)
+      collection.delete(fetch(arn))
+    end
+
+    def fetch(arn, &default)
+      default ||= -> { raise InvalidParameterValue, "Unknown platform endpoint #{arn}" }
+      found = collection.find do |platform_endpoint|
+        platform_endpoint["arn"] == arn
+      end
+      found || default.call
+    end
+
+  end
+end

--- a/lib/fake_sns/views/create_platform_application.xml.erb
+++ b/lib/fake_sns/views/create_platform_application.xml.erb
@@ -1,0 +1,8 @@
+<CreatePlatformApplicationResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <CreatePlatformApplicationResult>
+    <PlatformApplicationArn><%= arn %></PlatformApplicationArn>
+  </CreatePlatformApplicationResult>
+  <ResponseMetadata>
+    <RequestId><%= request_id %></RequestId>
+  </ResponseMetadata>
+</CreatePlatformApplicationResponse>

--- a/lib/fake_sns/views/create_platform_endpoint.xml.erb
+++ b/lib/fake_sns/views/create_platform_endpoint.xml.erb
@@ -1,0 +1,8 @@
+<CreatePlatformEndpointResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <CreatePlatformEndpointResult>
+    <EndpointArn><%= arn %></EndpointArn>
+  </CreatePlatformEndpointResult>
+  <ResponseMetadata>
+    <RequestId><%= request_id %></RequestId>
+  </ResponseMetadata>
+</CreatePlatformEndpointResponse>

--- a/spec/fake_sns/platform_applications_spec.rb
+++ b/spec/fake_sns/platform_applications_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe "Platform Applications" do
+
+it "creates a new platform application" do
+  arn = sns.create_platform_application(attributes: {}, name: "foo", platform: "bar").platform_application_arn
+  expect(arn).to match(/arn:aws:sns:us-east-1:(\w+)/)
+
+  new_arn = sns.create_platform_application(attributes: {}, name: "bar", platform: "baz").platform_application_arn
+  expect(new_arn).not_to eq arn
+
+  existing_arn = sns.create_platform_application(attributes: {}, name: "foo", platform: "bar").platform_application_arn
+  expect(existing_arn).to eq arn
+end
+
+end

--- a/spec/fake_sns/platform_endpoints_spec.rb
+++ b/spec/fake_sns/platform_endpoints_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe "Platform Endpoints" do
+
+it "creates a new platform endpoint" do
+  arn = sns.create_platform_endpoint(platform_application_arn: "foo", token: "bar").endpoint_arn
+  expect(arn).to match(/arn:aws:sns:us-east-1:(\w+)/)
+
+  new_arn = sns.create_platform_endpoint(platform_application_arn: "bar", token: "baz").endpoint_arn
+  expect(new_arn).not_to eq arn
+
+  existing_arn = sns.create_platform_endpoint(platform_application_arn: "foo", token: "bar").endpoint_arn
+  expect(existing_arn).to eq arn
+end
+
+end

--- a/spec/fake_sns/publish_spec.rb
+++ b/spec/fake_sns/publish_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Publishing" do
 
   let(:existing_topic) { sns.create_topic(name: "my-topic").topic_arn }
+  let(:existing_platform_endpoint) { sns.create_platform_endpoint(platform_application_arn: "app-arn", token: "token").endpoint_arn }
 
   it "remembers published messages" do
     message_id = sns.publish(topic_arn: existing_topic, message: "hallo").message_id
@@ -21,6 +22,14 @@ RSpec.describe "Publishing" do
     expect {
       sns.publish(topic_arn: existing_topic, message: "A" * 262145)
     }.to raise_error Aws::SNS::Errors::InvalidParameterValue
+  end
+
+  it "allows messages directly to a target ARN" do
+    message_id = sns.publish(target_arn: existing_platform_endpoint, message: "hallo").message_id
+    messages = $fake_sns.data.fetch("messages")
+    expect(messages.size).to eq 1
+    message = messages.first
+    expect(message.fetch(:id)).to eq message_id
   end
 
 end


### PR DESCRIPTION
This adds the `CreatePlatformApplication` and `CreatePlatformEndpoint` API calls and allows clients to publish messages directly to it.

There's a few test cases and "it works for me", but I'd be happy to change things around since I'm not terribly familiar with Ruby.
