### PR TITLE
Add delete messages endpoint

### DIFF
--- a/lib/fake_sns/database.rb
+++ b/lib/fake_sns/database.rb
@@ -34,6 +34,10 @@ module FakeSNS
       messages.reset
     end
 
+    def reset_messages
+      messages.reset
+    end
+
     def transaction
       store.transaction do
         yield

--- a/lib/fake_sns/server.rb
+++ b/lib/fake_sns/server.rb
@@ -45,6 +45,13 @@ module FakeSNS
       end
     end
 
+    delete "/messages" do
+      database.transaction do
+        database.reset_messages
+        200
+      end
+    end
+
     put "/" do
       database.replace(request.body.read)
       200


### PR DESCRIPTION
Hi!

I use fake sns for integration tests, where I have a server up and running (which also creates a topic). I simply want to remove the messages from SNS between each test method. I don't want to remove the complete topic definition.

This PR should allow me doing that via
curl -X DELETE http://127.0.0.1:9292/messages

Cheers
Ruwen
